### PR TITLE
feat: count real messages in example consumer

### DIFF
--- a/example/Dockerfile
+++ b/example/Dockerfile
@@ -1,25 +1,22 @@
-FROM python:3.6-slim
+FROM python:3.6-slim-jessie
 
 ################################################################################
 ## setup container
 ################################################################################
+
+RUN apt-get update -qq \
+    && apt-get -qq --yes --force-yes install gcc \
+    && pip install --upgrade pip
 
 ################################################################################
 ## install app
 ## copy files one by one and split commands to use docker cache
 ################################################################################
 
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends gcc  python-dev \
-    && rm -rf /var/lib/apt/lists/*
-
 WORKDIR /code
 
-COPY ./conf/pip /code/conf/pip
-
-RUN pip3 install -f /code/conf/pip/dependencies -r /code/conf/pip/requirements.txt
-
-RUN apt-get purge -y --auto-remove gcc python-dev
+COPY ./conf/pip /code/pip
+RUN pip install -r /code/pip/requirements.txt
 
 COPY ./ /code
 

--- a/example/app/main.py
+++ b/example/app/main.py
@@ -178,11 +178,22 @@ class KafkaViewer(object):
         size = sum([i for i in end_offsets.values()])
         return size
 
+    def print_topic_sizes(self, topics):
+        clear()
+        bold("Topic -> Count")
+        for t in topics:
+            size = self.count_all_topic_messages(t)
+            norm("%s -> %s" % (t, size))
+        wait()
+        clear()
+        return
+
     def topics(self):
         while True:
             topic_size = {}
             self.get_consumer(quiet=True)
             refresh_str = "-> Refresh Topics"
+            detailed_str = "-> Get Real Message Counts for Topics"
             quit_str = "-> Exit KafkaViewer\n"
             bold('Fetching Topics')
             topics = sorted([i for i in self.consumer.topics() if not i in EXCLUDED_TOPICS])
@@ -193,7 +204,7 @@ class KafkaViewer(object):
             clear()
             prompt_key = { "topic: %s {%s}" % (topic, topic_size[topic]) : topic for topic in topics }
             prompts = sorted(prompt_key.keys())
-            prompts.extend([refresh_str, quit_str])
+            prompts.extend([detailed_str, refresh_str, quit_str])
             bold("Choose a Topic to View")
             norm("-> topic {# of offsets in topic}\n")
             topic = self.ask(prompts)
@@ -203,6 +214,10 @@ class KafkaViewer(object):
             elif topic is refresh_str:
                 clear()
                 continue
+            elif topic is detailed_str:
+                self.print_topic_sizes(topics)
+                continue
+
             self.get_consumer(topic=topic)
             self.consumer.seek_to_beginning()
             self.show_topic()

--- a/example/app/main.py
+++ b/example/app/main.py
@@ -158,8 +158,10 @@ class KafkaViewer(object):
                     return sum(subtotals)
                 parts = [i for i in messages.keys()]
                 for part in parts:
-                    messages = messages.get(parts[part])
-                    subtotals.append(sum([1 for m in messages]))
+                    bundles = messages.get(part)
+                    for bundle in bundles:
+                        _msgs = bundle.get('messages')
+                        subtotals.append(sum([1 for m in _msgs]))
         except Exception as err:
             raise err
         finally:


### PR DESCRIPTION
Small improvements to the example consumer to give it more utility. It can now go through Kafka and unpack and count individual messages that have been serialized into bundles within Kafka topics.